### PR TITLE
Add a deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 aeson-options
 =============
 
-[![Build Status](https://travis-ci.org/serokell/aeson-options.svg)](https://travis-ci.org/serokell/aeson-options)
+**DEPRECATED**
+
+This library is deprecated because its maintainers considered it useless.
+The [aeson-casing](https://hackage.haskell.org/package/aeson-casing) package solves similar problems, consider using it instead.
+
 [![Hackage](https://img.shields.io/hackage/v/aeson-options.svg)](https://hackage.haskell.org/package/aeson-options)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Problem: we've decided to deprecate this library.

Solution: write about it in README, remove CI badge because there is
no reason to run CI for it anymore.